### PR TITLE
Remove spammy trace event left from debugging 

### DIFF
--- a/fdbserver/SimulatedCluster.actor.cpp
+++ b/fdbserver/SimulatedCluster.actor.cpp
@@ -48,6 +48,8 @@ const int MACHINE_REBOOT_TIME = 10;
 
 bool destructed = false;
 
+/*
+FIXME: Remove this?
 static const char* certBytes =
 	"-----BEGIN CERTIFICATE-----\n"
 	"MIIEGzCCAwOgAwIBAgIJANUQj1rRA2XMMA0GCSqGSIb3DQEBBQUAMIGjMQswCQYD\n"
@@ -101,6 +103,7 @@ static const char* certBytes =
 	"iastGId8HyONy3UPGPxCn4b95cIxKvdpt+hvWtYHIBCfHXluQK7zsDMgvtXjYNiz\n"
 	"peZRikYlwmu1K2YRTf7oLE2Ogw==\n"
 	"-----END PRIVATE KEY-----\n";
+*/
 
 template <class T>
 T simulate( const T& in ) {

--- a/flow/TLSPolicy.cpp
+++ b/flow/TLSPolicy.cpp
@@ -469,8 +469,6 @@ bool TLSPolicy::verify_peer(X509_STORE_CTX* store_ctx) {
 	bool verify_success;
 	std::string verify_failure_reason;
 
-	TraceEvent("TLSPolicyVerifyPeerCalled");
-
 	// Any matching rule is sufficient.
 	for (auto &verify_rule: rules) {
 		std::tie(verify_success, verify_failure_reason) = check_verify(&verify_rule, store_ctx, is_client);


### PR DESCRIPTION
And preemptively fix unused variable causing CMake builds to fail.