### PR TITLE
Fix --tls_password and add better error logging

### DIFF
--- a/fdbclient/NativeAPI.actor.cpp
+++ b/fdbclient/NativeAPI.actor.cpp
@@ -70,6 +70,7 @@ using std::pair;
 #define CERT_FILE_MAX_SIZE (5 * 1024 * 1024)
 
 NetworkOptions networkOptions;
+TLSParams tlsParams;
 static Reference<TLSPolicy> tlsPolicy;
 
 static void initTLSPolicy() {
@@ -890,38 +891,34 @@ void setNetworkOption(FDBNetworkOptions::Option option, Optional<StringRef> valu
 			break;
 		case FDBNetworkOptions::TLS_CERT_PATH:
 			validateOptionValue(value, true);
-			networkOptions.sslContext.use_certificate_chain_file(value.get().toString());
+			tlsParams.tlsCertPath = value.get().toString();
 			break;
 		case FDBNetworkOptions::TLS_CERT_BYTES: {
 			validateOptionValue(value, true);
-			std::string cert = value.get().toString();
-			networkOptions.sslContext.use_certificate(boost::asio::buffer(cert.data(), cert.size()), boost::asio::ssl::context::pem);
+			tlsParams.tlsCertBytes = value.get().toString();
 			break;
 		}
 		case FDBNetworkOptions::TLS_CA_PATH: {
 			validateOptionValue(value, true);
-			std::string cert = readFileBytes(value.get().toString(), CERT_FILE_MAX_SIZE);
-			networkOptions.sslContext.add_certificate_authority(boost::asio::buffer(cert.data(), cert.size()));
+			tlsParams.tlsCAPath = value.get().toString();
 			break;
 		}
 		case FDBNetworkOptions::TLS_CA_BYTES: {
 			validateOptionValue(value, true);
-			std::string cert = value.get().toString();
-			networkOptions.sslContext.add_certificate_authority(boost::asio::buffer(cert.data(), cert.size()));
+			tlsParams.tlsCABytes = value.get().toString();
 			break;
 		}
 		case FDBNetworkOptions::TLS_PASSWORD:
 			validateOptionValue(value, true);
-			networkOptions.tlsPassword = value.get().toString();
+			tlsParams.tlsPassword = value.get().toString();
 			break;
 		case FDBNetworkOptions::TLS_KEY_PATH:
 			validateOptionValue(value, true);		
-			networkOptions.sslContext.use_private_key_file(value.get().toString(), boost::asio::ssl::context::pem);
+			tlsParams.tlsKeyPath = value.get().toString();
 			break;
 		case FDBNetworkOptions::TLS_KEY_BYTES: {
 			validateOptionValue(value, true);
-			std::string cert = value.get().toString();
-			networkOptions.sslContext.use_private_key(boost::asio::buffer(cert.data(), cert.size()), boost::asio::ssl::context::pem);
+			tlsParams.tlsKeyBytes = value.get().toString();
 			break;
 		}
 		case FDBNetworkOptions::TLS_VERIFY_PEERS:
@@ -991,7 +988,7 @@ void setupNetwork(uint64_t transportId, bool useMetrics) {
 
 	initTLSPolicy();
 
-	g_network = newNet2(&networkOptions.sslContext, false, useMetrics || networkOptions.traceDirectory.present(), tlsPolicy, networkOptions.tlsPassword);
+	g_network = newNet2(&networkOptions.sslContext, false, useMetrics || networkOptions.traceDirectory.present(), tlsPolicy, tlsParams);
 	FlowTransport::createInstance(true, transportId);
 	Net2FileSystem::newFileSystem();
 }

--- a/fdbserver/fdbserver.actor.cpp
+++ b/fdbserver/fdbserver.actor.cpp
@@ -966,7 +966,7 @@ int main(int argc, char* argv[]) {
 
 		boost::asio::ssl::context sslContext(boost::asio::ssl::context::tlsv12);
 		Reference<TLSPolicy> tlsPolicy = Reference<TLSPolicy>(new TLSPolicy(TLSPolicy::Is::SERVER));
-		std::string tlsCertPath, tlsKeyPath, tlsCAPath, tlsPassword;
+		TLSParams tlsParams;
 		std::vector<std::string> tlsVerifyPeers;
 		double fileIoTimeout = 0.0;
 		bool fileIoWarnOnly = false;
@@ -1339,16 +1339,16 @@ int main(int argc, char* argv[]) {
 					args.OptionArg();
 					break;
 				case TLSOptions::OPT_TLS_CERTIFICATES:
-					tlsCertPath = args.OptionArg();
+					tlsParams.tlsCertPath = args.OptionArg();
 					break;
 				case TLSOptions::OPT_TLS_PASSWORD:
-					tlsPassword = args.OptionArg();
+					tlsParams.tlsPassword = args.OptionArg();
 					break;
 				case TLSOptions::OPT_TLS_CA_FILE:
-					tlsCAPath = args.OptionArg();
+					tlsParams.tlsCAPath = args.OptionArg();
 					break;
 				case TLSOptions::OPT_TLS_KEY:
-					tlsKeyPath = args.OptionArg();
+					tlsParams.tlsKeyPath = args.OptionArg();
 					break;
 				case TLSOptions::OPT_TLS_VERIFY_PEERS:
 					tlsVerifyPeers.push_back(args.OptionArg());
@@ -1556,21 +1556,11 @@ int main(int argc, char* argv[]) {
 			openTraceFile(NetworkAddress(), rollsize, maxLogsSize, logFolder, "trace", logGroup);
 		} else {
 #ifndef TLS_DISABLED
-			if ( tlsCertPath.size() ) {
-				sslContext.use_certificate_chain_file(tlsCertPath);
-			}
-			if (tlsCAPath.size()) {
-				std::string cert = readFileBytes(tlsCAPath, CERT_FILE_MAX_SIZE);
-				sslContext.add_certificate_authority(boost::asio::buffer(cert.data(), cert.size()));
-			}
-			if (tlsKeyPath.size()) {
-				sslContext.use_private_key_file(tlsKeyPath, boost::asio::ssl::context::pem);
-			}
 			if ( tlsVerifyPeers.size() ) {
 			  tlsPolicy->set_verify_peers( tlsVerifyPeers );
 			}
 #endif
-			g_network = newNet2(&sslContext, useThreadPool, true, tlsPolicy, tlsPassword);
+			g_network = newNet2(&sslContext, useThreadPool, true, tlsPolicy, tlsParams);
 			FlowTransport::createInstance(false, 1);
 
 			const bool expectsPublicAddress = (role == FDBD || role == NetworkTestServer || role == Restore);

--- a/flow/TLSPolicy.h
+++ b/flow/TLSPolicy.h
@@ -26,7 +26,13 @@
 #include <string>
 #include <vector>
 #include <openssl/x509.h>
+#include <boost/system/system_error.hpp>
 #include "flow/FastRef.h"
+
+struct TLSParams {
+	std::string tlsCertPath, tlsKeyPath, tlsCAPath, tlsPassword;
+	std::string tlsCertBytes, tlsKeyBytes, tlsCABytes;
+};
 
 typedef int NID;
 
@@ -69,17 +75,23 @@ public:
 		SERVER
 	};
 
-	bool set_verify_peers(std::vector<std::string> verify_peers);
-	bool verify_peer(bool preverified, X509_STORE_CTX* store_ctx);
-
 	TLSPolicy(Is client) : is_client(client == Is::CLIENT) {}
 	virtual ~TLSPolicy();
 
 	virtual void addref() { ReferenceCounted<TLSPolicy>::addref(); }
 	virtual void delref() { ReferenceCounted<TLSPolicy>::delref(); }
 
+	static std::string ErrorString(boost::system::error_code e);
+
+	bool set_verify_peers(std::vector<std::string> verify_peers);
+	bool verify_peer(bool preverified, X509_STORE_CTX* store_ctx);
+
+	std::string toString() const;
+
 	struct Rule {
 		explicit Rule(std::string input);
+
+		std::string toString() const;
 
 		std::map< NID, Criteria > subject_criteria;
 		std::map< NID, Criteria > issuer_criteria;

--- a/flow/network.h
+++ b/flow/network.h
@@ -406,7 +406,7 @@ typedef NetworkAddressList (*NetworkAddressesFuncPtr)();
 
 class INetwork;
 extern INetwork* g_network;
-extern INetwork* newNet2(boost::asio::ssl::context* sslContext, bool useThreadPool = false, bool useMetrics = false, Reference<TLSPolicy> policy = Reference<TLSPolicy>(), std::string tlsPassword = "");
+extern INetwork* newNet2(boost::asio::ssl::context* sslContext, bool useThreadPool = false, bool useMetrics = false, Reference<TLSPolicy> policy = Reference<TLSPolicy>(), const TLSParams& tlsParams = TLSParams());
 
 class INetwork {
 public:


### PR DESCRIPTION
This refactors all tls settings into a TLSParams object so that we can
set the password before loading any certificates.

It turns out that the FDBLibTLS code did really nice things with error
logging, but I just didn't understand openssl enough before to realize
what pieces I should be copying.